### PR TITLE
feat: add LM Studio as a new provider

### DIFF
--- a/src/ai-adapter/globals.ts
+++ b/src/ai-adapter/globals.ts
@@ -104,6 +104,19 @@ export const possibleModels: Models[] = [
 		imageReady: true,
 		provider: "ollama",
 	},
+	// [NEW PROVIDER] LM Studio default models
+	{
+		name: "google/gemma-4-e2b (LM Studio) [default]",
+		model: "google/gemma-4-e2b",
+		imageReady: true,
+		provider: "lmstudio",
+	},
+	{
+		name: "google/gemma-4-e2b (LM Studio)",
+		model: "google/gemma-4-e2b",
+		imageReady: false,
+		provider: "lmstudio",
+	},
 	// { [NEW PROVIDER]
 	// 	name: "EXAMPLE IMAGE",
 	// 	model: "exampleimage",

--- a/src/ai-adapter/providers/lmstudioProvider.ts
+++ b/src/ai-adapter/providers/lmstudioProvider.ts
@@ -1,0 +1,271 @@
+import AIImageAnalyzerPlugin from "../../main";
+import { Notice, Setting } from "obsidian";
+import { Provider } from "../provider";
+import { Models } from "../types";
+import { notifyModelsChange, possibleModels } from "../globals";
+import { saveSettings, settings } from "../../settings";
+import { debugLog } from "../../util";
+
+const context = "ai-adapter/providers/lmstudioProvider";
+
+export type LmStudioSettings = {
+	lastModel: Models;
+	lastImageModel: Models;
+	url: string;
+};
+
+export const DEFAULT_LMSTUDIO_SETTINGS: LmStudioSettings = {
+	lastModel: possibleModels[0],
+	lastImageModel: possibleModels[0],
+	url: "http://localhost:1234",
+};
+
+export class LmStudioProvider extends Provider {
+	private currentController: AbortController | undefined;
+
+	constructor() {
+		super();
+		this.lastModel =
+			settings.aiAdapterSettings.lmstudioSettings.lastModel;
+		this.lastImageModel =
+			settings.aiAdapterSettings.lmstudioSettings.lastImageModel;
+		this.checkLmStudio().then((success) => {
+			debugLog(context, "LM Studio check success: " + success);
+		});
+	}
+
+	generateSettings(containerEl: HTMLElement, plugin: AIImageAnalyzerPlugin) {
+		new Setting(containerEl).setName("LM Studio").setHeading();
+
+		new Setting(containerEl)
+			.setName("LM Studio URL")
+			.setDesc("Set the URL for the LM Studio server (OpenAI-compatible API)")
+			.addText((text) =>
+				text
+					// eslint-disable-next-line obsidianmd/ui/sentence-case
+					.setPlaceholder("Enter the host (http://localhost:1234)")
+					.setValue(settings.aiAdapterSettings.lmstudioSettings.url)
+					.onChange(async (value) => {
+						if (value.length === 0) {
+							value = DEFAULT_LMSTUDIO_SETTINGS.url;
+						}
+						settings.aiAdapterSettings.lmstudioSettings.url = value;
+						this.checkLmStudio().then((success) => {
+							debugLog(
+								context,
+								"LM Studio check success: " + success,
+							);
+						});
+						await saveSettings(plugin);
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Image model name")
+			.setDesc("Enter the model ID to use for image analysis (e.g. google/gemma-4-e2b)")
+			.addText((text) =>
+				text
+					.setPlaceholder("google/gemma-4-e2b")
+					.setValue(settings.aiAdapterSettings.selectedImageModel.model)
+					.onChange(async (value) => {
+						if (value.length === 0) return;
+						const model: Models = {
+							name: `${value} (LM Studio)`,
+							model: value,
+							imageReady: true,
+							provider: "lmstudio",
+						};
+						if (!possibleModels.some((pm) => pm.model === value && pm.imageReady)) {
+							possibleModels.push(model);
+						}
+						settings.aiAdapterSettings.selectedImageModel = model;
+						this.setLastImageModel(model);
+						await saveSettings(plugin);
+					}),
+			);
+	}
+
+	async queryHandling(prompt: string): Promise<string> {
+		const url = settings.aiAdapterSettings.lmstudioSettings.url;
+		const model = settings.aiAdapterSettings.selectedModel.model;
+
+		const controller = new AbortController();
+		this.currentController = controller;
+
+		try {
+			const response = await fetch(`${url}/v1/chat/completions`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				signal: controller.signal,
+				body: JSON.stringify({
+					model,
+					messages: [{ role: "user", content: prompt }],
+				}),
+			});
+
+			if (!response.ok) {
+				const errText = await response.text();
+				return `[AI-ERROR] LM Studio API error (${response.status}): ${errText}`;
+			}
+
+			const data = await response.json();
+			const content = data?.choices?.[0]?.message?.content;
+			if (!content) {
+				return "[AI-ERROR] No response from LM Studio API";
+			}
+			return content;
+		} finally {
+			if (this.currentController === controller) {
+				this.currentController = undefined;
+			}
+		}
+	}
+
+	async queryWithImageHandling(
+		prompt: string,
+		image: string,
+	): Promise<string> {
+		const url = settings.aiAdapterSettings.lmstudioSettings.url;
+		const model = settings.aiAdapterSettings.selectedImageModel.model;
+
+		const controller = new AbortController();
+		this.currentController = controller;
+
+		try {
+			const response = await fetch(`${url}/v1/chat/completions`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				signal: controller.signal,
+				body: JSON.stringify({
+					model,
+					messages: [
+						{
+							role: "user",
+							content: [
+								{ type: "text", text: prompt },
+								{
+									type: "image_url",
+									image_url: {
+										url: `data:image/png;base64,${image}`,
+									},
+								},
+							],
+						},
+					],
+				}),
+			});
+
+			if (!response.ok) {
+				const errText = await response.text();
+				return `[AI-ERROR] LM Studio API error (${response.status}): ${errText}`;
+			}
+
+			const data = await response.json();
+			const content = data?.choices?.[0]?.message?.content;
+			if (!content) {
+				return "[AI-ERROR] No response from LM Studio API";
+			}
+			return content;
+		} finally {
+			if (this.currentController === controller) {
+				this.currentController = undefined;
+			}
+		}
+	}
+
+	setLastModel(model: Models) {
+		super.setLastModel(model);
+		settings.aiAdapterSettings.lmstudioSettings.lastModel = model;
+	}
+
+	setLastImageModel(model: Models) {
+		super.setLastImageModel(model);
+		settings.aiAdapterSettings.lmstudioSettings.lastImageModel = model;
+	}
+
+	shutdown(): void {
+		debugLog(context, "Shutting down LM Studio provider");
+		if (this.currentController) {
+			try {
+				this.currentController.abort();
+			} catch {
+				// ignore
+			} finally {
+				this.currentController = undefined;
+			}
+		}
+	}
+
+	private async checkLmStudio(): Promise<boolean> {
+		const url = settings.aiAdapterSettings.lmstudioSettings.url;
+		try {
+			const response = await fetch(`${url}/v1/models`);
+			if (!response.ok) {
+				throw new Error(
+					`LM Studio returned HTTP ${response.status}`,
+				);
+			}
+
+			const data = await response.json();
+			const models: { id: string }[] = data?.data ?? [];
+			let updated = false;
+
+			for (const m of models) {
+				const modelId = m.id;
+				const modelName = `${modelId} (LM Studio)`;
+
+				// Add as image-capable model (multimodal)
+				if (
+					!possibleModels.some(
+						(pm) => pm.model === modelId && pm.imageReady,
+					)
+				) {
+					possibleModels.push({
+						name: modelName,
+						model: modelId,
+						imageReady: true,
+						provider: "lmstudio",
+					});
+					debugLog(context, "Added image model: " + modelName);
+					updated = true;
+				}
+
+				// Add as text model
+				if (
+					!possibleModels.some(
+						(pm) => pm.model === modelId && !pm.imageReady,
+					)
+				) {
+					possibleModels.push({
+						name: modelName,
+						model: modelId,
+						imageReady: false,
+						provider: "lmstudio",
+					});
+					debugLog(context, "Added text model: " + modelName);
+					updated = true;
+				}
+			}
+
+			if (updated) {
+				debugLog(context, "Models updated, notifying settings tab");
+				notifyModelsChange();
+			}
+
+			return true;
+		} catch (e) {
+			const errMsg =
+				e instanceof Error
+					? e.message
+					: typeof e === "string"
+						? e
+						: JSON.stringify(e);
+			debugLog(context, errMsg);
+			new Notice(
+				"Error connecting to LM Studio. Please check the URL and make sure LM Studio is running.",
+			);
+			new Notice(errMsg);
+			return false;
+		}
+	}
+}

--- a/src/ai-adapter/settings.ts
+++ b/src/ai-adapter/settings.ts
@@ -15,6 +15,10 @@ import {
 	DEFAULT_GEMINI_SETTINGS,
 	GeminiSettings,
 } from "./providers/geminiProvider";
+import {
+	DEFAULT_LMSTUDIO_SETTINGS,
+	LmStudioSettings,
+} from "./providers/lmstudioProvider"; // [NEW PROVIDER]
 import AIImageAnalyzerPlugin from "../main";
 import { saveSettings, settings } from "../settings";
 // import {DEFAULT_EXAMPLE_SETTINGS, ExampleSettings} from "./exampleProvider"; [NEW PROVIDER]
@@ -25,6 +29,7 @@ export type AIAdapterPluginSettings = {
 	selectedImageModel: Models;
 	ollamaSettings: OllamaSettings;
 	geminiSettings: GeminiSettings;
+	lmstudioSettings: LmStudioSettings; // [NEW PROVIDER]
 	// exampleSettings: ExampleSettings; [NEW PROVIDER]
 };
 
@@ -34,6 +39,7 @@ export const DEFAULT_SETTINGS: AIAdapterPluginSettings = {
 	selectedImageModel: possibleModels[0],
 	ollamaSettings: DEFAULT_OLLAMA_SETTINGS,
 	geminiSettings: DEFAULT_GEMINI_SETTINGS,
+	lmstudioSettings: DEFAULT_LMSTUDIO_SETTINGS, // [NEW PROVIDER]
 	// exampleSettings: DEFAULT_EXAMPLE_SETTINGS [NEW PROVIDER]
 };
 
@@ -41,6 +47,12 @@ export function generateSettings(
 	containerEl: HTMLElement,
 	plugin: AIImageAnalyzerPlugin,
 ) {
+	const providerDisplayNames: Record<Providers, string> = {
+		ollama: "Ollama",
+		gemini: "Gemini",
+		lmstudio: "LM Studio", // [NEW PROVIDER]
+	};
+
 	new Setting(containerEl)
 		.setName("Provider")
 		.setDesc("Select the provider to use")
@@ -49,7 +61,7 @@ export function generateSettings(
 				.addOptions(
 					providerNames.reduce(
 						(acc, provider) => {
-							acc[provider] = provider;
+							acc[provider] = providerDisplayNames[provider] ?? provider;
 							return acc;
 						},
 						{} as Record<Providers, string>,

--- a/src/ai-adapter/types.ts
+++ b/src/ai-adapter/types.ts
@@ -5,6 +5,6 @@ export type Models = {
 	provider: Providers;
 };
 
-export type Providers = "ollama" | "gemini"; // | "example" [NEW PROVIDER]
+export type Providers = "ollama" | "gemini" | "lmstudio"; // | "example" [NEW PROVIDER]
 
-export const providerNames: Providers[] = ["ollama", "gemini"]; //, "example"]; [NEW PROVIDER]
+export const providerNames: Providers[] = ["ollama", "gemini", "lmstudio"]; //, "example"]; [NEW PROVIDER]

--- a/src/ai-adapter/util.ts
+++ b/src/ai-adapter/util.ts
@@ -2,6 +2,7 @@ import { settings } from "../settings";
 import { Provider } from "./provider";
 import { OllamaProvider } from "./providers/ollamaProvider";
 import { GeminiProvider } from "./providers/geminiProvider";
+import { LmStudioProvider } from "./providers/lmstudioProvider"; // [NEW PROVIDER]
 import { provider } from "./globals";
 import { Notice } from "obsidian";
 import { debugLog } from "../util";
@@ -20,6 +21,9 @@ export function initProvider(): Provider {
 		}
 		case "gemini": {
 			return new GeminiProvider();
+		}
+		case "lmstudio": { // [NEW PROVIDER]
+			return new LmStudioProvider();
 		}
 		// case "testing": { [NEW PROVIDER]
 		// 	return new ExampleProvider();


### PR DESCRIPTION
## Summary
- Add LM Studio (OpenAI-compatible API) as a third provider alongside Ollama and Gemini
- Uses fetch-based `/v1/chat/completions` for image analysis and `/v1/models` for dynamic model discovery
- Includes a direct text input for model name in settings (useful when LM Studio server isn't running at settings time)
- Follows the existing `[NEW PROVIDER]` extension pattern documented in the codebase

## Motivation
LM Studio supports a wide range of multimodal models (e.g., `google/gemma-4-e2b`) that provide significantly better OCR accuracy for non-English text (Japanese, Chinese, etc.) compared to Ollama's llava models. Adding LM Studio as a provider enables users to leverage these models for image analysis.

## Changes
- **New file**: `src/ai-adapter/providers/lmstudioProvider.ts` — LM Studio provider implementation
- **Modified**: `types.ts`, `settings.ts`, `util.ts`, `globals.ts` — Provider registration (all at `[NEW PROVIDER]` markers)

## Test plan
- [x] Build succeeds with no errors
- [ ] Select LM Studio as provider in settings
- [ ] Enter LM Studio server URL and model name
- [ ] Analyze an image via right-click menu
- [ ] Verify keywords are generated and cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)