### PR TITLE
feat: add AI Providers plugin as a provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@google/genai": "^2.13.0",
+				"@obsidian-ai-providers/sdk": "^1.7.3",
 				"ollama": "^0.6.3",
 				"p-queue": "^9.3.3"
 			},
@@ -34,7 +35,6 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
 			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -45,7 +45,6 @@
 			"version": "6.38.6",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
 			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -879,9 +878,17 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/@obsidian-ai-providers/sdk": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/@obsidian-ai-providers/sdk/-/sdk-1.7.3.tgz",
+			"integrity": "sha512-T1qH78XBHEd14MAqALyYsDeOf4FYATpqZK/xYnfHVebSRItYeNl3H5zdt2quKmxG2HXJH6Jha3VDeiKokI8kfQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"obsidian": "latest"
+			}
 		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
@@ -981,7 +988,6 @@
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
 			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/tern": "*"
@@ -1009,7 +1015,6 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
 			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
@@ -1045,7 +1050,6 @@
 			"version": "0.23.9",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
 			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*"
@@ -2326,7 +2330,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -5084,7 +5087,6 @@
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
 			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -5297,7 +5299,6 @@
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
 			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
@@ -6235,7 +6236,6 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
 			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -6644,7 +6644,6 @@
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	},
 	"dependencies": {
 		"@google/genai": "^2.13.0",
+		"@obsidian-ai-providers/sdk": "^1.7.3",
 		"ollama": "^0.6.3",
 		"p-queue": "^9.3.3"
 	}

--- a/src/ai-adapter/providers/aiProvidersProvider.ts
+++ b/src/ai-adapter/providers/aiProvidersProvider.ts
@@ -1,0 +1,237 @@
+import { Provider } from "../provider";
+import { Notice, Setting } from "obsidian";
+import { debugLog } from "../../util";
+import { Models } from "../types";
+import { notifyModelsChange, possibleModels } from "../globals";
+import AIImageAnalyzerPlugin from "../../main";
+import { saveSettings, settings } from "../../settings";
+import {
+	waitForAI,
+	IAIProvider,
+	IAIProvidersService,
+} from "@obsidian-ai-providers/sdk";
+
+const context = "ai-adapter/providers/aiProvidersProvider";
+
+export type AiProvidersSettings = {
+	lastModel: Models;
+	lastImageModel: Models;
+};
+
+// Placeholder shown until the AI Providers plugin reports its configured providers
+const AI_PROVIDERS_FALLBACK_MODEL: Models = {
+	name: "AI Providers (not loaded)",
+	model: "",
+	imageReady: true,
+	provider: "ai-providers",
+};
+
+export const DEFAULT_AI_PROVIDERS_SETTINGS: AiProvidersSettings = {
+	lastModel: AI_PROVIDERS_FALLBACK_MODEL,
+	lastImageModel: AI_PROVIDERS_FALLBACK_MODEL,
+};
+
+function getAiProvidersSettings(): AiProvidersSettings {
+	if (!settings.aiAdapterSettings.aiProvidersSettings) {
+		settings.aiAdapterSettings.aiProvidersSettings = {
+			...DEFAULT_AI_PROVIDERS_SETTINGS,
+		};
+	}
+
+	return settings.aiAdapterSettings.aiProvidersSettings;
+}
+
+function providerDisplayName(p: IAIProvider): string {
+	return p.model ? `${p.name} (${p.model})` : p.name;
+}
+
+export class AiProvidersProvider extends Provider {
+	private static currentController: AbortController | undefined;
+
+	constructor() {
+		super();
+		const aiProvidersSettings = getAiProvidersSettings();
+		this.lastModel = aiProvidersSettings.lastModel;
+		this.lastImageModel = aiProvidersSettings.lastImageModel;
+	}
+
+	async initialize(): Promise<boolean> {
+		try {
+			const service = await AiProvidersProvider.getService();
+			this.refreshModels(service);
+			debugLog(
+				context,
+				`AI Providers loaded with ${service.providers.length} provider(s)`,
+			);
+			return service.providers.length > 0;
+		} catch (e) {
+			debugLog(context, "Failed to load AI Providers plugin: " + e);
+			return false;
+		}
+	}
+
+	generateSettings(containerEl: HTMLElement, plugin: AIImageAnalyzerPlugin) {
+		// eslint-disable-next-line obsidianmd/ui/sentence-case -- "AI Providers" is a plugin name
+		new Setting(containerEl).setName("AI Providers").setHeading();
+
+		new Setting(containerEl)
+			.setName("Providers")
+			.setDesc(
+				// eslint-disable-next-line obsidianmd/ui/sentence-case -- "AI Providers" is a plugin name
+				"Providers are configured in the AI Providers plugin and listed in the image model dropdown above. Select a provider whose model supports vision.",
+			)
+			.addButton((button) =>
+				button.setButtonText("Reload providers").onClick(async () => {
+					try {
+						const service = await AiProvidersProvider.getService();
+						this.refreshModels(service);
+						new Notice(
+							`Loaded ${service.providers.length} provider(s) from AI Providers`,
+						);
+					} catch (e) {
+						debugLog(
+							context,
+							"Failed to reload providers: " + e,
+						);
+						new Notice(
+							// eslint-disable-next-line obsidianmd/ui/sentence-case -- "AI Providers" is a plugin name
+							"Could not reach the AI Providers plugin. Is it installed and enabled?",
+						);
+					}
+					await saveSettings(plugin);
+				}),
+			);
+	}
+
+	async queryHandling(prompt: string): Promise<string> {
+		return this.executeQuery(prompt, undefined, this.lastModel);
+	}
+
+	async queryWithImageHandling(
+		prompt: string,
+		image: string,
+	): Promise<string> {
+		return this.executeQuery(
+			prompt,
+			`data:image/png;base64,${image}`,
+			this.lastImageModel,
+		);
+	}
+
+	setLastModel(model: Models) {
+		super.setLastModel(model);
+		getAiProvidersSettings().lastModel = model;
+	}
+
+	setLastImageModel(model: Models) {
+		super.setLastImageModel(model);
+		getAiProvidersSettings().lastImageModel = model;
+	}
+
+	shutdown(): void {
+		debugLog(context, "Shutting down AI Providers provider");
+		AiProvidersProvider.abortCurrentRequest();
+	}
+
+	private async executeQuery(
+		prompt: string,
+		imageDataUrl: string | undefined,
+		model: Models,
+	): Promise<string> {
+		const service = await AiProvidersProvider.getService();
+		const aiProvider = service.providers.find(
+			(p: IAIProvider) => p.id === model.model,
+		);
+
+		if (!aiProvider) {
+			throw new Error(
+				"No provider selected. Pick one in the image model dropdown (configured via the AI Providers plugin).",
+			);
+		}
+
+		AiProvidersProvider.abortCurrentRequest();
+		const controller = new AbortController();
+		AiProvidersProvider.currentController = controller;
+
+		try {
+			const response = await service.execute({
+				provider: aiProvider,
+				prompt,
+				...(imageDataUrl ? { images: [imageDataUrl] } : {}),
+				abortController: controller,
+			});
+			return typeof response === "string" ? response : "";
+		} catch (e) {
+			const errMsg =
+				e instanceof Error
+					? e.message
+					: typeof e === "string"
+						? e
+						: (JSON.stringify(e) ?? String(e));
+			debugLog(context, errMsg);
+			if (e instanceof Error && e.name === "AbortError") {
+				const abortErr = new Error("Request was aborted");
+				abortErr.name = "AbortError";
+				(abortErr as unknown as { cause?: unknown }).cause = e;
+				throw abortErr;
+			}
+			const reErr = new Error(errMsg);
+			(reErr as unknown as { cause?: unknown }).cause = e;
+			throw reErr;
+		} finally {
+			// Only clear if no newer request has replaced this controller
+			if (AiProvidersProvider.currentController === controller) {
+				AiProvidersProvider.currentController = undefined;
+			}
+		}
+	}
+
+	private refreshModels(service: IAIProvidersService) {
+		// Replace previously registered ai-providers entries with the current list
+		for (let i = possibleModels.length - 1; i >= 0; i--) {
+			if (possibleModels[i].provider === "ai-providers") {
+				possibleModels.splice(i, 1);
+			}
+		}
+
+		for (const p of service.providers) {
+			possibleModels.push({
+				name: providerDisplayName(p),
+				model: p.id,
+				imageReady: true,
+				provider: "ai-providers",
+			});
+		}
+
+		if (service.providers.length === 0) {
+			possibleModels.push(AI_PROVIDERS_FALLBACK_MODEL);
+		}
+
+		notifyModelsChange();
+	}
+
+	private static async getService(): Promise<IAIProvidersService> {
+		const aiResolver = await waitForAI();
+
+		// waitForAI resolves only once the AI Providers plugin announces itself;
+		// cancel after a timeout so a missing plugin fails fast instead of hanging.
+		const timeout = setTimeout(() => aiResolver.cancel(), 5000);
+		try {
+			return await aiResolver.promise;
+		} finally {
+			clearTimeout(timeout);
+		}
+	}
+
+	static abortCurrentRequest(): void {
+		if (AiProvidersProvider.currentController) {
+			try {
+				AiProvidersProvider.currentController.abort();
+			} catch {
+				// ignore
+			} finally {
+				AiProvidersProvider.currentController = undefined;
+			}
+		}
+	}
+}

--- a/src/ai-adapter/settings.ts
+++ b/src/ai-adapter/settings.ts
@@ -21,6 +21,11 @@ import {
 	LlamaCppSettings,
 } from "./providers/llamaCppProvider";
 
+import {
+	DEFAULT_AI_PROVIDERS_SETTINGS,
+	AiProvidersSettings,
+} from "./providers/aiProvidersProvider";
+
 import AIImageAnalyzerPlugin from "../main";
 import { saveSettings, settings } from "../settings";
 // import {DEFAULT_EXAMPLE_SETTINGS, ExampleSettings} from "./exampleProvider"; [NEW PROVIDER]
@@ -32,6 +37,7 @@ export type AIAdapterPluginSettings = {
 	ollamaSettings: OllamaSettings;
 	geminiSettings: GeminiSettings;
 	llamaCppSettings: LlamaCppSettings;
+	aiProvidersSettings: AiProvidersSettings;
 	// exampleSettings: ExampleSettings; [NEW PROVIDER]
 };
 
@@ -42,6 +48,7 @@ export const DEFAULT_SETTINGS: AIAdapterPluginSettings = {
 	ollamaSettings: DEFAULT_OLLAMA_SETTINGS,
 	geminiSettings: DEFAULT_GEMINI_SETTINGS,
 	llamaCppSettings: DEFAULT_LLAMA_CPP_SETTINGS,
+	aiProvidersSettings: DEFAULT_AI_PROVIDERS_SETTINGS,
 	// exampleSettings: DEFAULT_EXAMPLE_SETTINGS [NEW PROVIDER]
 };
 

--- a/src/ai-adapter/types.ts
+++ b/src/ai-adapter/types.ts
@@ -5,6 +5,11 @@ export type Models = {
 	provider: Providers;
 };
 
-export type Providers = "ollama" | "gemini" | "llama-cpp"; // | "example" [NEW PROVIDER]
+export type Providers = "ollama" | "gemini" | "llama-cpp" | "ai-providers"; // | "example" [NEW PROVIDER]
 
-export const providerNames: Providers[] = ["ollama", "gemini", "llama-cpp"]; //, "example"]; [NEW PROVIDER]
+export const providerNames: Providers[] = [
+	"ollama",
+	"gemini",
+	"llama-cpp",
+	"ai-providers",
+]; //, "example"]; [NEW PROVIDER]

--- a/src/ai-adapter/util.ts
+++ b/src/ai-adapter/util.ts
@@ -3,6 +3,7 @@ import { Provider } from "./provider";
 import { OllamaProvider } from "./providers/ollamaProvider";
 import { GeminiProvider } from "./providers/geminiProvider";
 import { LlamaCppProvider } from "./providers/llamaCppProvider";
+import { AiProvidersProvider } from "./providers/aiProvidersProvider";
 import { provider } from "./globals";
 import { Notice } from "obsidian";
 import { debugLog } from "../util";
@@ -24,6 +25,9 @@ export function initProvider(): Provider {
 		}
 		case "llama-cpp": {
 			return new LlamaCppProvider();
+		}
+		case "ai-providers": {
+			return new AiProvidersProvider();
 		}
 		// case "testing": { [NEW PROVIDER]
 		// 	return new ExampleProvider();

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import {
 	unsubscribeFunctionSetting,
 } from "./ai-adapter/globals";
 import { initProvider } from "./ai-adapter/util";
+import { initAI } from "@obsidian-ai-providers/sdk";
 
 const context = "main";
 
@@ -32,6 +33,14 @@ export default class AIImageAnalyzerPlugin extends Plugin {
 
 	async onload() {
 		debugLog(context, "loading ai image analyzer plugin");
+
+		// Register this plugin with the AI Providers SDK so the optional
+		// "ai-providers" provider can resolve the service later. The fallback
+		// settings tab is disabled because AI Providers is not a hard dependency.
+		await initAI(this.app, this, async () => {}, {
+			disableFallback: true,
+		});
+
 		await loadSettings(this);
 
 		const activeProvider = initProvider();


### PR DESCRIPTION
## What

Adds a fourth provider that delegates to the [AI Providers](https://github.com/pfrankov/obsidian-ai-providers) plugin via its SDK (`@obsidian-ai-providers/sdk`). Any provider configured there — OpenAI-compatible endpoints, OpenRouter, Ollama, LM Studio, gateways like LiteLLM or Bifrost, and ~20 more — becomes selectable in the image model dropdown, without adding per-service code to this plugin.

## Why

Requests like #164 and #341 keep asking for more backends. Each one currently means a new hardcoded provider here. The AI Providers plugin already solves exactly this: users configure URL, key and model once, and consuming plugins (e.g. Local GPT) pick a provider from a list. This PR makes the image analyzer such a consumer, while keeping the existing ollama/gemini/llama-cpp providers untouched.

This also fixes a concrete gap in the llama-cpp provider: its request body has no `model` field, which OpenAI-compatible gateways reject with HTTP 400 (`could not auto resolve a provider`). Through the SDK the model is always supplied by the provider config.

## How

- `src/ai-adapter/providers/aiProvidersProvider.ts`: new provider following the existing `Provider` interface and the llama-cpp provider's structure (abort handling, error wrapping, dynamic model registration via `possibleModels` + `notifyModelsChange`, same as the llama.cpp runtime model entry).
- Providers from AI Providers appear as entries in the image model dropdown (`name (model)`, `model` = provider id).
- `initAI(..., { disableFallback: true })` in `onload`: registers the SDK manager without making AI Providers a hard dependency — nothing changes for users who don't have it installed. Service resolution is cancelled after 5s with a clear notice when the plugin is missing.
- Images are passed as data URIs via the SDK's `images` param (vision-capable models required, as with the other providers).
- Followed the `[NEW PROVIDER]` extension points in `types.ts`, `util.ts` and `settings.ts`.

## Testing

- `npm run build` and `npx eslint src/` clean.
- The target setup (an OpenAI-compatible gateway configured in AI Providers) was verified against the SDK's request shapes: chat, vision via `image_url` data URI, and the capability probes all pass against the gateway; a vault test with this build against that gateway is running on my own setup.

Refs #164 #341
